### PR TITLE
support for python 3.12 3.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(gh-actions): "
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(dependencies): "

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,7 +23,12 @@
           - name: Set up Python version
             uses: actions/setup-python@v5
             with:
-              python-version: '3.11'
+              python-version: |
+                3.9
+                3.10
+                3.11
+                3.12
+                3.13
           - name: Install extra dependencies
             run: |
               python -m pip install --upgrade pip
@@ -51,12 +56,7 @@
           - name: Set up Python version
             uses: actions/setup-python@v5
             with:
-              python-version: |
-                3.9
-                3.10
-                3.11
-                3.12
-                3.13
+              python-version: '3.13'
           - name: Build package
             run: |
               python -m pip install --upgrade build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,7 +51,12 @@
           - name: Set up Python version
             uses: actions/setup-python@v5
             with:
-              python-version: '3.11'
+              python-version: |
+                3.9
+                3.10
+                3.11
+                3.12
+                3.13
           - name: Build package
             run: |
               python -m pip install --upgrade build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - August, 2024
+
+### Features
+
+* Support for Python3.12 and Python 3.13
+
 ## [0.2.0] - January, 2024
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Meteole allows you to retrieve forecasts for a wide range of weather indicators.
 *note : the date of the run cannot be more than 4 days in the past. Consequently, change the date of the run in the example below.*
 
 ```python
-import datetime as dt 
+import datetime as dt
 from meteole import AromeForecast
 
 # Configure the logger to provide information on data recovery: recovery status, default settings, etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meteole"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">3.8.0"
 description = "A Python client library for forecast model APIs (e.g., Météo-France)."
 readme = "README.md"
@@ -26,14 +26,15 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    # "Programming Language :: Python :: 3.12", no wheels 3.12 for dependency ecmwflibs
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
 ]
 
 dependencies = [
     "pandas>=2.0.0",
-    "ecmwflibs>=0.6.3",
-    "cfgrib>=0.0.11.0",
+    "eccodes>=2.39.0",
+    "cfgrib>=0.9.10.4",
     "requests>=2.31.0",
     "xarray>=2024.5.0",
     "xmltodict>=0.13.0",


### PR DESCRIPTION
### What?
Add support to python 3.12 and python 3.13

To do this, replace ecmwflibs (not compatible with python >3.11) by eccodes

https://github.com/ecmwf/ecmwflibs/issues/33

### Have you done?

- [x] Code tests
- [x] Update documentation
- [x] Update [changelog](https://github.com/MAIF/meteole/blob/main/CHANGELOG.md)

### Linked issues: (optional)
Fix #44 
